### PR TITLE
Enable multiple chat windows within the same game

### DIFF
--- a/src/ChatClosedButton.js
+++ b/src/ChatClosedButton.js
@@ -15,6 +15,6 @@ export default class ChatClosedButton extends React.Component {
 }
 
 ChatClosedButton.propTypes = {
-  scope: PropTypes.oneOfType(["lobby", "round"]).isRequired,
+  scope: PropTypes.oneOfType([s=>{s=="lobby"}, s=>{s=="round"}]).isRequired,
   onClickButton: PropTypes.func.isRequired,
 };

--- a/src/ChatFooter.js
+++ b/src/ChatFooter.js
@@ -16,16 +16,18 @@ export default class ChatFooter extends React.Component {
       const { scope } = this.props;
 
       if (scope === "round") {
-        const { stage, player } = this.props;
+        const { stage, player, chatId } = this.props;
         stage.append("chat", {
           text,
           playerId: player._id,
+          chatId,
         });
       } else {
-        const { game, player } = this.props;
+        const { game, player, chatId } = this.props;
         game.append("chat", {
           text,
           playerId: player._id,
+          chatId
         });
       }
 

--- a/src/ChatFooter.js
+++ b/src/ChatFooter.js
@@ -65,7 +65,7 @@ export default class ChatFooter extends React.Component {
 }
 
 ChatFooter.propTypes = {
-  scope: PropTypes.oneOfType(["lobby", "round"]).isRequired,
+  scope: PropTypes.oneOfType([s=>{s=="lobby"}, s=>{s=="round"}]).isRequired,
   player: PropTypes.object.isRequired,
   stage: PropTypes.object,
   game: PropTypes.object,

--- a/src/ChatHeader.js
+++ b/src/ChatHeader.js
@@ -17,6 +17,6 @@ export default class ChatHeader extends React.Component {
 }
 
 ChatHeader.propTypes = {
-  scope: PropTypes.oneOfType(["lobby", "round"]).isRequired,
+  scope: PropTypes.oneOfType([s=>{s=="lobby"}, s=>{s=="round"}]).isRequired,
   onClickButton: PropTypes.func.isRequired,
 };

--- a/src/ChatLog.js
+++ b/src/ChatLog.js
@@ -29,9 +29,10 @@ export default class ChatLog extends React.Component {
 }
 
 ChatLog.propTypes = {
-  scope: PropTypes.oneOfType(["lobby", "round"]).isRequired,
+  scope: PropTypes.oneOfType([s=>{s=="lobby"}, s=>{s=="round"}]).isRequired,
   messages: PropTypes.array.isRequired,
   stage: PropTypes.object,
   game: PropTypes.object,
   player: PropTypes.object.isRequired,
+  chatId: PropTypes.string.isRequired,
 };

--- a/src/ChatLog.js
+++ b/src/ChatLog.js
@@ -7,10 +7,11 @@ import "./style.less";
 
 export default class ChatLog extends React.Component {
   render() {
-    const { scope, player, messages } = this.props;
+    const { scope, player, messages, chatId } = this.props;
     let footerProps = {
       scope,
       player,
+      chatId
     };
 
     footerProps =

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -43,7 +43,7 @@ export default class Messages extends React.Component {
 }
 
 Messages.propTypes = {
-  scope: PropTypes.oneOfType(["lobby", "round"]).isRequired,
+  scope: PropTypes.oneOfType([s=>{s=="lobby"}, s=>{s=="round"}]).isRequired,
   messages: PropTypes.array.isRequired,
   player: PropTypes.object,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ export class Chat extends React.Component {
 
   render() {
     const { isChatOpen } = this.state;
-    const { stage, game, player, chatId, showHeader } = this.props;
+    const { stage, game, player, chatId, showHeader, fixWindow } = this.props;
 
     const messages = stage.get("chat")
       ? _.filter(stage.get("chat"), {"chatId":chatId}).map(({ text, playerId }) => ({
@@ -41,7 +41,7 @@ export class Chat extends React.Component {
     return (
       <div className="empirica-chat-container">
         {isChatOpen ? (
-          <div className="empirica-chat-open">
+          <div className={fixWindow ? "empirica-chat-open-fixed" : "empirica-chat-open-float"}>
             {showHeader && <ChatHeader scope="round" onClickButton={this.onClickButton} />}
             <ChatLog scope="round" messages={messages} stage={stage} player={player} chatId={chatId}/>
           </div>
@@ -58,12 +58,14 @@ Chat.propTypes = {
   player: PropTypes.object.isRequired,
   game: PropTypes.object.isRequired,
   chatId: PropTypes.string,  // happens after defaultProps is resolved
-  showHeader: PropTypes.bool
+  showHeader: PropTypes.bool,
+  fixWindow: PropTypes.bool,
 };
 
 Chat.defaultProps = {
   chatId: "",
-  showHeader: true
+  showHeader: true,
+  fixWindow: true,
 }
 
 export class LobbyChat extends React.Component {

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ export class Chat extends React.Component {
 
   render() {
     const { isChatOpen } = this.state;
-    const { stage, game, player, chatId } = this.props;
+    const { stage, game, player, chatId, showHeader } = this.props;
 
     const messages = stage.get("chat")
       ? _.filter(stage.get("chat"), {"chatId":chatId}).map(({ text, playerId }) => ({
@@ -42,9 +42,8 @@ export class Chat extends React.Component {
       <div className="empirica-chat-container">
         {isChatOpen ? (
           <div className="empirica-chat-open">
-            <ChatHeader scope="round" onClickButton={this.onClickButton} />
-            <ChatLog scope="round" messages={messages}
-              stage={stage} player={player} chatId={chatId}/>
+            {showHeader && <ChatHeader scope="round" onClickButton={this.onClickButton} />}
+            <ChatLog scope="round" messages={messages} stage={stage} player={player} chatId={chatId}/>
           </div>
         ) : (
           <ChatClosedButton scope="round" onClickButton={this.onClickButton} />
@@ -59,10 +58,12 @@ Chat.propTypes = {
   player: PropTypes.object.isRequired,
   game: PropTypes.object.isRequired,
   chatId: PropTypes.string,  // happens after defaultProps is resolved
+  showHeader: PropTypes.bool
 };
 
 Chat.defaultProps = {
-  chatId: ""
+  chatId: "",
+  showHeader: true
 }
 
 export class LobbyChat extends React.Component {

--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,6 @@ export class Chat extends React.Component {
   render() {
     const { isChatOpen } = this.state;
     const { stage, game, player, chatId } = this.props;
-    // Todo: if id is undefined, set it to 'default' or ''
 
     const messages = stage.get("chat")
       ? _.filter(stage.get("chat"), {"chatId":chatId}).map(({ text, playerId }) => ({
@@ -59,7 +58,12 @@ Chat.propTypes = {
   stage: PropTypes.object.isRequired,
   player: PropTypes.object.isRequired,
   game: PropTypes.object.isRequired,
+  chatId: PropTypes.string,  // happens after defaultProps is resolved
 };
+
+Chat.defaultProps = {
+  chatId: ""
+}
 
 export class LobbyChat extends React.Component {
   constructor(props) {

--- a/src/index.js
+++ b/src/index.js
@@ -29,10 +29,11 @@ export class Chat extends React.Component {
 
   render() {
     const { isChatOpen } = this.state;
-    const { stage, game, player } = this.props;
+    const { stage, game, player, chatId } = this.props;
+    // Todo: if id is undefined, set it to 'default' or ''
 
     const messages = stage.get("chat")
-      ? stage.get("chat").map(({ text, playerId }) => ({
+      ? _.filter(stage.get("chat"), {"chatId":chatId}).map(({ text, playerId }) => ({
           text,
           subject: game.players.find(p => p._id === playerId),
         }))
@@ -43,7 +44,8 @@ export class Chat extends React.Component {
         {isChatOpen ? (
           <div className="empirica-chat-open">
             <ChatHeader scope="round" onClickButton={this.onClickButton} />
-            <ChatLog scope="round" messages={messages} stage={stage} player={player} />
+            <ChatLog scope="round" messages={messages}
+              stage={stage} player={player} chatId={chatId}/>
           </div>
         ) : (
           <ChatClosedButton scope="round" onClickButton={this.onClickButton} />

--- a/src/style.less
+++ b/src/style.less
@@ -5,15 +5,10 @@
 .empirica-chat-container {
   display: flex;
 
+
   .empirica-chat-open {
-    margin-left: 2rem;
-    flex-grow: 0;
-    flex-shrink: 0;
-    width: 38rem;
+
     max-height: 100%;
-    position: fixed;
-    bottom: 0px;
-    right: 0px;
     z-index: 99;
 
     .header {
@@ -141,6 +136,22 @@
         }
       }
     }
+  }
+
+  .empirica-chat-open-fixed {
+    position: fixed;
+    bottom: 0px;
+    right: 0px;
+    flex-grow: 0;
+    flex-shrink: 0;
+    width: 38rem;
+    margin-left: 2rem;
+    .empirica-chat-open();
+  }
+
+  .empirica-chat-open-float {
+    min-width: 30rem;
+    .empirica-chat-open();
   }
 
   .empirica-chat-close {


### PR DESCRIPTION
Addressing https://github.com/empiricaly/meteor-empirica-core/issues/109.
Added a few new pieces to make it easy to have multiple chat windows. Each player can be assigned to participate in an arbitrary number of simultaneous chats, and each chat can have an arbitrary number of people in it. For example, two chat rooms below (left and right) each with a different number of (overlapping) participants.

![image](https://user-images.githubusercontent.com/4304478/77576393-87800b00-6eab-11ea-85cc-5c29e4b11958.png)

Added a few properties to the Chat object to make this work:

- **chatId**: `string`, the (internal) name of the chat room. Can be anything. If you create rooms specifically for sets of people, a nice convention could be to use a concatenation of the playerIds of whoever is going to see the room. If not included, defaults to an empty string `""`, preserving the baseline behavior of a single chat room.

- **showHeader**: `bool` controlling whether the top bar of the chat window (with the title and the minimize button) is rendered or not. If you're putting a chat window as part of the main display, you may want to encase it in other components, and probably don't want the users to be able to minimize the chat window. Defaults to `true`, to preserve the baseline behavior.

- **fixWindow**: `bool` controlling whether the chat window will be fixed in the bottom right corner of the page. If `false` then display like a normal component. Defaults to `true` to preserve the baseline behavior.


I'm still learning the ropes with js, so if there is anything that's not best-practice, let me know!

